### PR TITLE
Add SSH Enable Step

### DIFF
--- a/OTG.md
+++ b/OTG.md
@@ -62,6 +62,10 @@ dtoverlay=dwc2
 gpu_mem=16
 ```
 
+#### Enable SSH
+
+Now to enable SSH create a file named `/boot/ssh` with no extension. If you're on a Mac you can probably do this: `touch /Volumes/boot/ssh`.
+
 *Now unmount the boot partition.*
 
 #### Set the hostname


### PR DESCRIPTION
As of November 2016 SSH was disabled by default in Raspbian images.  This pull request adds information to enable SSH during OTG Kernel preparation.  I should also cite the @alexellis blog post [Carry a Docker Engine in Your Pocket](http://blog.alexellis.io/docker-engine-in-your-pocket/) as the source for the content of this change.